### PR TITLE
feat: Add a default CORS Setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1.0.141"
 serde_json = "1.0.83"
 uuid = { version = "1.1.2", features = ["v4"] }
 datta = "0.1"
+tower-http = { version = "0.4.0", features = ["cors"] }
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }

--- a/src/servient.rs
+++ b/src/servient.rs
@@ -52,6 +52,9 @@ pub struct Servient<Other: ExtendableThing = Nil> {
 
 impl Servient<Nil> {
     /// Instantiate a ThingBuilder with its Form augmented with [`HttpRouter`] methods.
+    ///
+    /// By default it sets the CORS headers to allow any origin, you may disable the behaviour
+    /// by calling [ServientSettings::http_disable_permissive_cors].
     pub fn builder(title: impl Into<String>) -> ThingBuilder<NilPlus<ServientExtension>, ToExtend> {
         ThingBuilder::<NilPlus<ServientExtension>, ToExtend>::new(title)
     }
@@ -157,6 +160,7 @@ mod test {
             .finish_extend()
             .http_bind(addr)
             .thing_type(ThingType::Directory)
+            .http_disable_permissive_cors()
             .build_servient()
             .unwrap();
 


### PR DESCRIPTION
Setting the CORS headers to allow any origin let browsers to act as consumers. 

See https://github.com/sifis-home/demo-things/issues/20